### PR TITLE
Remove Async executors and replace with tokio as a feature

### DIFF
--- a/crazyflie-link/Cargo.toml
+++ b/crazyflie-link/Cargo.toml
@@ -16,16 +16,14 @@ exclude = [
 
 [dependencies]
 bitflags = "1.0"
-crazyradio = { version="0.3.0", features = ["shared_radio", "async"], optional = true }
-crazyradio-webusb = { version="0.2", optional = true }
-wasm-timer = { version="0.2.5", optional = true }
+crazyradio = { version="0.3.0", features = ["shared_radio", "async"]}
 flume = "0.10"
 log = "0.4"
 rand = "0.8"
 thiserror = "1"
 url = "2.2"
 hex = "0.4.3"
-tokio = { version = "1.36.0", features = ["full"], optional = true }
+tokio = { version = "1.36.0", features = ["full"]}
 futures = "0.3"
 futures-util = "0.3"
 futures-channel = "0.3"
@@ -34,9 +32,3 @@ futures-channel = "0.3"
 anyhow = "1"
 byteorder = "1.2.2"
 structopt = "0.3"
-
-[features]
-default = ["native", "tokio"]
-tokio = ["dep:tokio"]
-native = ["crazyradio"]
-webusb = ["crazyradio-webusb", "wasm-timer"]

--- a/crazyflie-link/Cargo.toml
+++ b/crazyflie-link/Cargo.toml
@@ -25,7 +25,7 @@ rand = "0.8"
 thiserror = "1"
 url = "2.2"
 hex = "0.4.3"
-async_executors = { version = "0.4.1" }
+tokio = { version = "1.36.0", features = ["full"], optional = true }
 futures = "0.3"
 futures-util = "0.3"
 futures-channel = "0.3"
@@ -34,10 +34,9 @@ futures-channel = "0.3"
 anyhow = "1"
 byteorder = "1.2.2"
 structopt = "0.3"
-"async-std" = { version = "1.9", features = ["attributes"] }
-async_executors = { version = "0.4.1", features = ["async_std"]}
 
 [features]
-default = ["native"]
+default = ["native", "tokio"]
+tokio = ["dep:tokio"]
 native = ["crazyradio"]
 webusb = ["crazyradio-webusb", "wasm-timer"]

--- a/crazyflie-link/README.md
+++ b/crazyflie-link/README.md
@@ -7,18 +7,7 @@ This crates implements low-level link communication to a [Crazyflie] using the
 bidirectional radio connection.
 
 
-This crate API is async, the [async_executor] crate is used to abstract the async
-executor. Examples are using `async-std`.
-
-## Cargo features
-
-By default the `native` feature is used which make use of the [Crazyradio crate]
-which in turn uses `libusb` to access the Crazyradio. This will work on Linux,
-Mac and Windows natively.
-
-By disabling default features and enabling the feature `webusb`, the
-[Crazyradio-webusb crate] will be used which allows to compile the link to wasm
-in order to run in a WebUSB-compatible web-browser.
+This crate API is async, it is implemented using the Tokio executor.
 
 ## Limitations
 

--- a/crazyflie-link/examples/benchmark.rs
+++ b/crazyflie-link/examples/benchmark.rs
@@ -1,5 +1,5 @@
 // Simple benchmark test, test ping time and duplex bandwidth
-use async_std::future::timeout;
+use tokio::time::timeout;
 use crazyflie_link::{LinkContext, Packet};
 use futures::Future;
 use std::{
@@ -39,11 +39,11 @@ async fn purge_crazyflie_queues(link: &crazyflie_link::Connection) {
     }
 }
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let opt = Opt::from_args();
 
-    let link_context = LinkContext::new(async_executors::AsyncStd);
+    let link_context = LinkContext::new();
     let link = link_context.open_link(&opt.link_uri).await?;
 
     println!("Test ping:");

--- a/crazyflie-link/examples/console.rs
+++ b/crazyflie-link/examples/console.rs
@@ -1,14 +1,14 @@
-use async_std::future::timeout;
+use tokio::time::{Duration, timeout};
 use crazyflie_link::LinkContext;
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let link_context = LinkContext::new(async_executors::AsyncStd);
+    let link_context = LinkContext::new();
 
     let link = link_context.open_link("radio://0/60/2M/E7E7E7E7E7").await?;
 
     loop {
-        let packet = timeout(std::time::Duration::from_secs(10), link.recv_packet())
+        let packet = timeout(Duration::from_secs(10), link.recv_packet())
             .await?
             .unwrap();
         let data = packet.get_data();

--- a/crazyflie-link/examples/disconnect.rs
+++ b/crazyflie-link/examples/disconnect.rs
@@ -1,17 +1,17 @@
 use std::sync::Arc;
-use std::time::Duration;
+use tokio::time::{sleep, Duration};
 
 use crazyflie_link::LinkContext;
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let link_context = LinkContext::new(async_executors::AsyncStd);
+    let link_context = LinkContext::new();
 
     println!("Connecting the first time");
     let link = Arc::new(link_context.open_link("radio://0/60/2M/E7E7E7E7E7").await?);
 
     let link_task = link.clone();
-    async_std::task::spawn(async move {
+    tokio::spawn(async move {
         let reason = link_task.wait_close().await;
         println!(
             " -= after wait_close() =- The link seem to have been closed for reason \"{}\"!",
@@ -19,29 +19,29 @@ async fn main() -> anyhow::Result<()> {
         );
     });
 
-    async_std::task::sleep(Duration::from_secs(2)).await;
+    sleep(Duration::from_secs(2)).await;
 
     println!("Closing the connection");
     link.close().await;
     println!("Waiting 3 seconds");
-    async_std::task::sleep(Duration::from_secs(3)).await;
+    sleep(Duration::from_secs(3)).await;
 
     println!("Connecting the second time");
     let link = link_context.open_link("radio://0/60/2M/E7E7E7E7E7").await?;
 
-    async_std::task::sleep(Duration::from_secs(2)).await;
+    sleep(Duration::from_secs(2)).await;
 
     println!("Dropping link object");
     drop(link);
     println!("Waiting 3 seconds");
-    async_std::task::sleep(Duration::from_secs(3)).await;
+    sleep(Duration::from_secs(3)).await;
 
     println!("Connecting and dropping directly");
     let link = link_context.open_link("radio://0/60/2M/E7E7E7E7E7").await?;
     drop(link);
 
     println!("Waiting 3 seconds");
-    async_std::task::sleep(Duration::from_secs(3)).await;
+    sleep(Duration::from_secs(3)).await;
 
     Ok(())
 }

--- a/crazyflie-link/examples/scan.rs
+++ b/crazyflie-link/examples/scan.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use crazyflie_link::LinkContext;
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<()> {
-    let context = crate::LinkContext::new(async_executors::AsyncStd);
+    let context = crate::LinkContext::new();
 
     let found = context.scan([0xe7; 5]).await?;
 

--- a/crazyflie-link/src/connection.rs
+++ b/crazyflie-link/src/connection.rs
@@ -11,10 +11,7 @@ use std::sync::Arc;
 
 use std::time;
 
-#[cfg(feature = "native")]
 use std::time::Instant;
-#[cfg(feature = "webusb")]
-use wasm_timer::Instant;
 
 const EMPTY_PACKET_BEFORE_RELAX: u32 = 10;
 

--- a/crazyflie-link/src/connection.rs
+++ b/crazyflie-link/src/connection.rs
@@ -2,8 +2,6 @@
 use crate::crazyradio::{Channel, SharedCrazyradio};
 use crate::error::Result;
 use crate::Packet;
-use async_executors::LocalSpawnHandle;
-use async_executors::{JoinHandle, LocalSpawnHandleExt};
 use futures_channel::oneshot;
 use futures_util::lock::Mutex;
 use log::{debug, info, warn};
@@ -44,13 +42,11 @@ pub struct Connection {
     uplink: flume::Sender<Vec<u8>>,
     downlink: flume::Receiver<Vec<u8>>,
     disconnect_channel: flume::Receiver<()>,
-    disconnect: Arc<AtomicBool>,
-    _thread_handle: JoinHandle<()>,
+    disconnect: Arc<AtomicBool>
 }
 
 impl Connection {
     pub(crate) async fn new(
-        executor: Arc<dyn LocalSpawnHandle<()> + Sync + Send>,
         radio: Arc<SharedCrazyradio>,
         channel: Channel,
         address: [u8; 5],
@@ -79,8 +75,7 @@ impl Connection {
             flags,
             disconnect: disconnect.clone(),
         };
-        let thread_handle = executor
-            .spawn_handle_local(async move {
+        tokio::spawn(async move {
                 if let Err(e) = thread.run(connection_initialized_send).await {
                     thread
                         .update_status(ConnectionStatus::Disconnected(format!(
@@ -90,8 +85,7 @@ impl Connection {
                         .await;
                 }
                 drop(thread.disconnect_channel);
-            })
-            .expect("Spawning connection task");
+            });
 
         // Wait for, either, the connection being established or failed initialization
         connection_initialized.await.unwrap();
@@ -101,8 +95,7 @@ impl Connection {
             disconnect_channel: disconnect_channel_rx,
             uplink: uplink_send,
             downlink: downlink_recv,
-            disconnect,
-            _thread_handle: thread_handle,
+            disconnect
         })
     }
 

--- a/crazyflie-link/src/context.rs
+++ b/crazyflie-link/src/context.rs
@@ -16,16 +16,14 @@ use url::Url;
 
 /// Context for the link connections
 pub struct LinkContext {
-    radios: Mutex<BTreeMap<usize, Weak<SharedCrazyradio>>>,
-    executor: Arc<dyn async_executors::LocalSpawnHandle<()> + Send + Sync>,
+    radios: Mutex<BTreeMap<usize, Weak<SharedCrazyradio>>>
 }
 
 impl LinkContext {
     /// Create a new link context
-    pub fn new(executor: impl async_executors::LocalSpawnHandle<()> + Send + Sync + 'static) -> Self {
+    pub fn new() -> Self {
         Self {
-            radios: Mutex::new(BTreeMap::new()),
-            executor: Arc::new(executor),
+            radios: Mutex::new(BTreeMap::new())
         }
     }
 
@@ -151,6 +149,6 @@ impl LinkContext {
 
         let radio = self.get_radio(radio_nth).await?;
 
-        Connection::new(self.executor.clone(), radio, channel, address, flags).await
+        Connection::new(radio, channel, address, flags).await
     }
 }

--- a/crazyflie-link/src/lib.rs
+++ b/crazyflie-link/src/lib.rs
@@ -39,16 +39,7 @@ mod context;
 mod error;
 mod packet;
 
-#[cfg(all(feature = "native", feature = "webusb"))]
-compile_error!("feature \"native\" and feature \"webusb\" cannot be enabled at the same time");
-
-#[cfg(not(feature = "tokio"))]
-compile_error!("feature \"tokio\" must be enabled at this time");
-
-#[cfg(feature = "native")]
 pub(crate) use crazyradio;
-#[cfg(feature = "webusb")]
-pub(crate) use crazyradio_webusb as crazyradio;
 
 pub use connection::{Connection, ConnectionStatus};
 pub use context::LinkContext;

--- a/crazyflie-link/src/lib.rs
+++ b/crazyflie-link/src/lib.rs
@@ -8,10 +8,6 @@
 //! The entry point to this Crate is the [LinkContext], it keeps track of Crazyradio dongles
 //! and provides functions to open a link [Connection].
 //!
-//! Since this crate spawns async tasks, it needs to know about what async executor to use.
-//! The [async_executors] crate is used to support the common async executors and should be
-//! passed to the context constructor.
-//!
 //! A connection can then be used to send and receive packet with the Crazyflie.
 //!
 //! Example:
@@ -20,7 +16,7 @@
 //! # use std::error::Error;
 //! # async fn test() -> Result<(), Box<dyn Error>> {
 //! // Create a link Context
-//! let context = crazyflie_link::LinkContext::new(async_executors::AsyncStd);
+//! let context = crazyflie_link::LinkContext::new();
 //!
 //! // Scan for Crazyflies
 //! let cf_found = context.scan([0xe7; 5]).await?;
@@ -34,7 +30,6 @@
 //! # }
 //! ```
 //!
-//! [async_executors]: https://crates.io/crates/async_executors
 
 #[macro_use]
 extern crate bitflags;
@@ -46,6 +41,9 @@ mod packet;
 
 #[cfg(all(feature = "native", feature = "webusb"))]
 compile_error!("feature \"native\" and feature \"webusb\" cannot be enabled at the same time");
+
+#[cfg(not(feature = "tokio"))]
+compile_error!("feature \"tokio\" must be enabled at this time");
 
 #[cfg(feature = "native")]
 pub(crate) use crazyradio;

--- a/python-binding/Cargo.toml
+++ b/python-binding/Cargo.toml
@@ -10,8 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 crazyflie-link = { path = "../crazyflie-link" }
-async-std = "1.9"
-async_executors = { version = "0.4.1", features = ["async_std"] }
+tokio = { version = "1.36.0", features = ["full"] }
 
 [dependencies.pyo3]
 version = "0.21.2"


### PR DESCRIPTION
This PR removes the usage of `async_executors` and instead moves to a feature based implementation which uses a feature to select the async runtime used by the lib. The only current implementation of this is `tokio`, so this feature needs to be set otherwise the lib will not compile.