### PR TITLE
Add support for connecting to a Crazyflie via USB

### DIFF
--- a/crazyflie-link/Cargo.toml
+++ b/crazyflie-link/Cargo.toml
@@ -28,6 +28,7 @@ futures = "0.3"
 futures-util = "0.3"
 futures-channel = "0.3"
 rusb = "0.9.4"
+async-trait = "0.1.83"
 
 [dev-dependencies]
 anyhow = "1"

--- a/crazyflie-link/Cargo.toml
+++ b/crazyflie-link/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { version = "1.36.0", features = ["full"]}
 futures = "0.3"
 futures-util = "0.3"
 futures-channel = "0.3"
+rusb = "0.9.4"
 
 [dev-dependencies]
 anyhow = "1"

--- a/crazyflie-link/src/connection.rs
+++ b/crazyflie-link/src/connection.rs
@@ -1,5 +1,5 @@
-use crate::Packet;
 use crate::error::Result;
+use crate::Packet;
 use async_trait::async_trait;
 
 /// Describe the current link connection status
@@ -16,7 +16,6 @@ pub enum ConnectionStatus {
 // Describes the interface for a connection to a Crazyflie
 #[async_trait]
 pub trait ConnectionTrait {
-
     /// Wait for the connection to be closed. Returns the message stored in the
     /// disconnected connection status that indicate the reason for the disconnection
     async fn wait_close(&self) -> String;
@@ -47,23 +46,22 @@ pub trait ConnectionTrait {
     /// This function can return an error if the connection task is not active anymore.
     /// This can happen if the Crazyflie is disconnected due to a timeout
     async fn recv_packet(&self) -> Result<Packet>;
-
 }
 
 /// Connection to a Crazyflie
 pub struct Connection {
-    /// Reference to the internal connection object 
-    internal_connection: Box<dyn ConnectionTrait + Send + Sync>
+    /// Reference to the internal connection object
+    internal_connection: Box<dyn ConnectionTrait + Send + Sync>,
 }
 
 impl Connection {
     /// Create a new connection object
     pub fn new(internal_connection: Box<dyn ConnectionTrait + Send + Sync>) -> Self {
         Self {
-            internal_connection
+            internal_connection,
         }
     }
-    
+
     /// Wait for the connection to be closed. Returns the message stored in the
     /// disconnected connection status that indicate the reason for the disconnection
     pub async fn wait_close(&self) -> String {

--- a/crazyflie-link/src/connection.rs
+++ b/crazyflie-link/src/connection.rs
@@ -1,26 +1,6 @@
-// Connection handling code
-use crate::crazyradio::{Channel, SharedCrazyradio};
-use crate::error::Result;
 use crate::Packet;
-use futures_channel::oneshot;
-use futures_util::lock::Mutex;
-use log::{debug, info, warn};
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering::Relaxed;
-use std::sync::Arc;
-
-use std::time;
-
-use std::time::Instant;
-
-const EMPTY_PACKET_BEFORE_RELAX: u32 = 10;
-
-bitflags! {
-    pub struct ConnectionFlags: u32 {
-        const SAFELINK = 0b00000001;
-        const ACKFILTER = 0b00000010;
-    }
-}
+use crate::error::Result;
+use async_trait::async_trait;
 
 /// Describe the current link connection status
 #[derive(Clone, Debug)]
@@ -33,321 +13,55 @@ pub enum ConnectionStatus {
     Disconnected(String),
 }
 
-/// Link connection
+#[async_trait]
+pub trait ConnectionTrait {
+
+ async fn wait_close(&self) -> String;
+
+ async fn close(&self);
+
+ async fn status(&self) -> ConnectionStatus;
+
+ async fn wait_disconnect(&self);
+
+ async fn send_packet(&self, packet: Packet) -> Result<()>;
+
+ async fn recv_packet(&self) -> Result<Packet>;
+
+}
+
 pub struct Connection {
-    status: Arc<Mutex<ConnectionStatus>>,
-    uplink: flume::Sender<Vec<u8>>,
-    downlink: flume::Receiver<Vec<u8>>,
-    disconnect_channel: flume::Receiver<()>,
-    disconnect: Arc<AtomicBool>
+    internal_connection: Box<dyn ConnectionTrait + Send + Sync>
 }
 
 impl Connection {
-    pub(crate) async fn new(
-        radio: Arc<SharedCrazyradio>,
-        channel: Channel,
-        address: [u8; 5],
-        flags: ConnectionFlags,
-    ) -> Result<Connection> {
-        let status = Arc::new(Mutex::new(ConnectionStatus::Connecting));
-
-        let (disconnect_channel_tx, disconnect_channel_rx) = flume::bounded(0);
-        let disconnect = Arc::new(AtomicBool::new(false));
-
-        let (uplink_send, uplink_recv) = flume::bounded(1000);
-        let (downlink_send, downlink_recv) = flume::bounded(1000);
-
-        let (connection_initialized_send, connection_initialized) = oneshot::channel();
-
-        let mut thread = ConnectionThread {
-            radio,
-            status: status.clone(),
-            disconnect_channel: disconnect_channel_tx,
-            safelink_down_ctr: 0,
-            safelink_up_ctr: 0,
-            uplink: uplink_recv,
-            downlink: downlink_send,
-            channel,
-            address,
-            flags,
-            disconnect: disconnect.clone(),
-        };
-        tokio::spawn(async move {
-                if let Err(e) = thread.run(connection_initialized_send).await {
-                    thread
-                        .update_status(ConnectionStatus::Disconnected(format!(
-                            "Connection error: {}",
-                            e
-                        )))
-                        .await;
-                }
-                drop(thread.disconnect_channel);
-            });
-
-        // Wait for, either, the connection being established or failed initialization
-        connection_initialized.await.unwrap();
-
-        Ok(Connection {
-            status,
-            disconnect_channel: disconnect_channel_rx,
-            uplink: uplink_send,
-            downlink: downlink_recv,
-            disconnect
-        })
+    pub fn new(internal_connection: Box<dyn ConnectionTrait + Send + Sync>) -> Self {
+        Self {
+            internal_connection
+        }
     }
 
-    /// Wait for the connection to be closed. Returns the message stored in the
-    /// disconnected connection status that indicate the reason for the disconnection
     pub async fn wait_close(&self) -> String {
-        // Wait for the connection thread to drop the disconnect channel
-        let _ = self.disconnect_channel.recv_async().await;
-        if let ConnectionStatus::Disconnected(reason) = self.status().await {
-            reason
-        } else {
-            "Still connected!".to_owned()
-        }
+        self.internal_connection.wait_close().await
     }
 
-    /// Close the connection and wait for the connection task to stop.
-    ///
-    /// The connection can also be closed by simply dropping the connection object.
-    /// Though, if the connection task is currently processing a packet, it will continue running
-    /// until the current packet has been processed. This function will wait for any ongoing packet
-    /// to be processed and for the communication task to stop.
     pub async fn close(&self) {
-        self.disconnect.store(true, Relaxed);
-        let _ = self.disconnect_channel.recv_async().await;
+        self.internal_connection.close().await
     }
 
-    /// Return the connection status
     pub async fn status(&self) -> ConnectionStatus {
-        self.status.lock().await.clone()
+        self.internal_connection.status().await
     }
 
-    /// Block until the connection is dropped. The `status()` function can be used to get the reason
-    /// for the disconnection.
     pub async fn wait_disconnect(&self) {
-        // The channel will return an error when the other side, in the connection thread, is dropped
-        let _ = self.disconnect_channel.recv_async().await;
+        self.internal_connection.wait_disconnect().await
     }
 
-    /// Send a packet to the connected Crazyflie
-    ///
-    /// This fundtion can return an error if the connection task is not active anymore.
-    /// This can happen if the Crazyflie is disconnected due to a timeout
     pub async fn send_packet(&self, packet: Packet) -> Result<()> {
-        self.uplink.send_async(packet.into()).await?;
-        Ok(())
+        self.internal_connection.send_packet(packet).await
     }
 
-    /// Receive a packet from the connected Crazyflie
-    ///
-    /// This fundtion can return an error if the connection task is not active anymore.
-    /// This can happen if the Crazyflie is disconnected due to a timeout
     pub async fn recv_packet(&self) -> Result<Packet> {
-        let packet = self.downlink.recv_async().await?;
-        Ok(packet.into())
-    }
-}
-
-impl Drop for Connection {
-    fn drop(&mut self) {
-        self.disconnect.store(true, Relaxed);
-    }
-}
-
-struct ConnectionThread {
-    radio: Arc<SharedCrazyradio>,
-    status: Arc<Mutex<ConnectionStatus>>,
-    disconnect_channel: flume::Sender<()>,
-    safelink_up_ctr: u8,
-    safelink_down_ctr: u8,
-    uplink: flume::Receiver<Vec<u8>>,
-    downlink: flume::Sender<Vec<u8>>,
-    channel: Channel,
-    address: [u8; 5],
-    flags: ConnectionFlags,
-    disconnect: Arc<AtomicBool>,
-}
-
-impl ConnectionThread {
-    async fn update_status(&self, new_status: ConnectionStatus) {
-        debug!("New status: {:?}", &new_status);
-        let mut status = self.status.lock().await;
-        *status = new_status;
-    }
-
-    async fn enable_safelink(&mut self) -> Result<bool> {
-        // Tying 10 times to reset safelink
-        for _ in 0..10 {
-            let (ack, payload) = self
-                .radio
-                .send_packet_async(self.channel, self.address, vec![0xff, 0x05, 0x01])
-                .await?;
-
-            if ack.received && payload == [0xff, 0x05, 0x01] {
-                self.safelink_down_ctr = 0;
-                self.safelink_up_ctr = 0;
-
-                // Safelink enabled!
-                return Ok(true);
-            }
-        }
-        Ok(false)
-    }
-
-    async fn send_packet_safe(
-        &mut self,
-        packet: Vec<u8>,
-    ) -> Result<(crate::crazyradio::Ack, Vec<u8>)> {
-        let mut packet = packet;
-        packet[0] &= 0xF3;
-        packet[0] |= (self.safelink_up_ctr << 3) | (self.safelink_down_ctr << 2);
-
-        let (ack, mut ack_payload) = self
-            .radio
-            .send_packet_async(self.channel, self.address, packet)
-            .await?;
-
-        if ack.received {
-            self.safelink_up_ctr = 1 - self.safelink_up_ctr;
-        }
-
-        if ack.received
-            && !ack_payload.is_empty()
-            && (ack_payload[0] & 0x04) >> 2 == self.safelink_down_ctr
-        {
-            self.safelink_down_ctr = 1 - self.safelink_down_ctr;
-        } else {
-            // If the down counter does not match, this is a reapeted ack and the payload needs to be dropped
-            ack_payload.clear();
-        }
-
-        Ok((ack, ack_payload))
-    }
-
-    async fn send_packet(
-        &mut self,
-        packet: Vec<u8>,
-        safe: bool,
-    ) -> Result<(crate::crazyradio::Ack, Vec<u8>)> {
-        let result = if safe {
-            self.send_packet_safe(packet).await?
-        } else {
-            self.radio
-                .send_packet_async(self.channel, self.address, packet)
-                .await?
-        };
-
-        Ok(result)
-    }
-
-    fn use_safelink(&self) -> bool {
-        self.flags.contains(ConnectionFlags::SAFELINK)
-    }
-
-    //
-    // In order to know whether or not to handle and send this ack back to
-    // the receiver we need to check some stuff.
-    //
-    // In safelink we deem a payload empty if it only containx 0xF3, and we do
-    // not handle it.
-    //
-    // When not using safelink (perhaps communicating with bootloader) we check
-    // if the ackfilter flag is not set. If we have no ack filter then we
-    // handle payload-less acks as well.
-    //
-    fn preprocess_ack(&self, payload: &mut Vec<u8>, safelink: bool) -> bool {
-        if safelink {
-            if !payload.is_empty() && payload[0] & 0xF3 != 0xF3 {
-                payload[0] &= 0xF3;
-                return true;
-            }
-            return false;
-        }
-
-        // not safelink
-
-        if !payload.is_empty() {
-            return true;
-        }
-
-        if !self.flags.contains(ConnectionFlags::ACKFILTER) {
-            *payload = vec![0xFF];
-            return true;
-        }
-
-        false
-    }
-
-    async fn run(&mut self, connection_initialized: oneshot::Sender<()>) -> Result<()> {
-        info!("Connecting to {:?}/{:X?} ...", self.channel, self.address);
-
-        // Try to initialize safelink if in use
-        let safelink = self.use_safelink() && self.enable_safelink().await?;
-
-        self.update_status(ConnectionStatus::Connected).await;
-        connection_initialized.send(()).unwrap();
-
-        // Communication loop ...
-        let mut last_pk_time = Instant::now();
-        let mut n_empty_packets = 0;
-        let mut packet = vec![0xff];
-        let mut needs_resend = false;
-        while last_pk_time.elapsed() < time::Duration::from_millis(1000) {
-            if !needs_resend {
-                packet = if self.uplink.is_empty() {
-                    vec![0xff]
-                } else {
-                    self.uplink.recv_async().await?
-                }
-            }
-
-            let (ack, mut ack_payload) = self.send_packet(packet.clone(), safelink).await?;
-
-            debug!("Packet sent!");
-
-            if ack.received {
-                last_pk_time = Instant::now();
-                needs_resend = false;
-
-                // Add some relaxation time if the Crazyflie has nothing to send back
-                // for a while
-
-                let should_handle = self.preprocess_ack(&mut ack_payload, safelink);
-                if should_handle {
-                    self.downlink.send(ack_payload)?;
-                } else if n_empty_packets > EMPTY_PACKET_BEFORE_RELAX {
-                    // If no packet received for a while, relax packet pulling
-                } else {
-                    n_empty_packets += 1;
-                }
-            } else {
-                debug!("Lost packet!");
-                needs_resend = true;
-            }
-
-            // If the connection object has been dropped, leave the thread
-            if self.disconnect.load(Relaxed) {
-                debug!("Disconnect requested, leaving connection loop.");
-                self.update_status(ConnectionStatus::Disconnected(
-                    "Connection closed".to_owned(),
-                ))
-                .await;
-                return Ok(());
-            }
-        }
-
-        self.update_status(ConnectionStatus::Disconnected(
-            "Connection timeout".to_string(),
-        ))
-        .await;
-
-        warn!(
-            "Connection to {:?}/{:X?} lost (timeout)",
-            self.channel, self.address
-        );
-
-        Ok(())
+        self.internal_connection.recv_packet().await
     }
 }

--- a/crazyflie-link/src/connection.rs
+++ b/crazyflie-link/src/connection.rs
@@ -13,54 +13,96 @@ pub enum ConnectionStatus {
     Disconnected(String),
 }
 
+// Describes the interface for a connection to a Crazyflie
 #[async_trait]
 pub trait ConnectionTrait {
 
- async fn wait_close(&self) -> String;
+    /// Wait for the connection to be closed. Returns the message stored in the
+    /// disconnected connection status that indicate the reason for the disconnection
+    async fn wait_close(&self) -> String;
 
- async fn close(&self);
+    /// Close the connection and wait for the connection task to stop.
+    ///
+    /// The connection can also be closed by simply dropping the connection object.
+    /// Though, if the connection task is currently processing a packet, it will continue running
+    /// until the current packet has been processed. This function will wait for any ongoing packet
+    /// to be processed and for the communication task to stop.
+    async fn close(&self);
 
- async fn status(&self) -> ConnectionStatus;
+    /// Return the connection status
+    async fn status(&self) -> ConnectionStatus;
 
- async fn wait_disconnect(&self);
+    /// Block until the connection is dropped. The `status()` function can be used to get the reason
+    /// for the disconnection.
+    async fn wait_disconnect(&self);
 
- async fn send_packet(&self, packet: Packet) -> Result<()>;
+    /// Send a packet to the connected Crazyflie
+    ///
+    /// This function can return an error if the connection task is not active anymore.
+    /// This can happen if the Crazyflie is disconnected due to a timeout
+    async fn send_packet(&self, packet: Packet) -> Result<()>;
 
- async fn recv_packet(&self) -> Result<Packet>;
+    /// Receive a packet from the connected Crazyflie
+    ///
+    /// This function can return an error if the connection task is not active anymore.
+    /// This can happen if the Crazyflie is disconnected due to a timeout
+    async fn recv_packet(&self) -> Result<Packet>;
 
 }
 
+/// Connection to a Crazyflie
 pub struct Connection {
+    /// Reference to the internal connection object 
     internal_connection: Box<dyn ConnectionTrait + Send + Sync>
 }
 
 impl Connection {
+    /// Create a new connection object
     pub fn new(internal_connection: Box<dyn ConnectionTrait + Send + Sync>) -> Self {
         Self {
             internal_connection
         }
     }
-
+    
+    /// Wait for the connection to be closed. Returns the message stored in the
+    /// disconnected connection status that indicate the reason for the disconnection
     pub async fn wait_close(&self) -> String {
         self.internal_connection.wait_close().await
     }
 
+    /// Close the connection and wait for the connection task to stop.
+    ///
+    /// The connection can also be closed by simply dropping the connection object.
+    /// Though, if the connection task is currently processing a packet, it will continue running
+    /// until the current packet has been processed. This function will wait for any ongoing packet
+    /// to be processed and for the communication task to stop.
     pub async fn close(&self) {
         self.internal_connection.close().await
     }
 
+    /// Return the connection status
     pub async fn status(&self) -> ConnectionStatus {
         self.internal_connection.status().await
     }
 
+    /// Block until the connection is dropped. The `status()` function can be used to get the reason
+    /// for the disconnection.
     pub async fn wait_disconnect(&self) {
         self.internal_connection.wait_disconnect().await
     }
 
+    /// Send a packet to the connected Crazyflie
+    ///
+    /// This function can return an error if the connection task is not active anymore.
+    /// This can happen if the Crazyflie is disconnected due to a timeout
     pub async fn send_packet(&self, packet: Packet) -> Result<()> {
         self.internal_connection.send_packet(packet).await
     }
 
+    /// Receive a packet from the connected Crazyflie
+    ///
+    /// This function can return an error if the connection task is not active anymore.
+    /// This can happen if the Crazyflie is disconnected due to a timeout
     pub async fn recv_packet(&self) -> Result<Packet> {
         self.internal_connection.recv_packet().await
     }

--- a/crazyflie-link/src/context.rs
+++ b/crazyflie-link/src/context.rs
@@ -6,16 +6,13 @@
 use crate::connection::Connection;
 use crate::connection::ConnectionTrait;
 use crate::crazyflie_usb_connection::CrazyflieUSBConnection;
-use crate::crazyradio::Channel;
 use crate::crazyradio::SharedCrazyradio;
 use crate::crazyradio_connection::CrazyradioConnection;
 use crate::error::{Error, Result};
 use futures_util::lock::Mutex;
 
-use rusb::DeviceList;
 use std::collections::BTreeMap;
 use std::sync::{Arc, Weak};
-use std::time::Duration;
 
 /// Context for the link connections
 pub struct LinkContext {

--- a/crazyflie-link/src/context.rs
+++ b/crazyflie-link/src/context.rs
@@ -56,59 +56,10 @@ impl LinkContext {
     ///
     /// It returns a list of URIs that can be passed to the [LinkContext::open_link()] function.
     pub async fn scan(&self, address: [u8; 5]) -> Result<Vec<String>> {
-        let channels = match self.get_radio(0).await {
-            Ok(radio) => {
-                radio
-                    .scan_async(
-                        Channel::from_number(0)?,
-                        Channel::from_number(125)?,
-                        address,
-                        vec![0xff],
-                    )
-                    .await?
-            }
-            Err(_) => Vec::new(),
-        };
-
         let mut found = Vec::new();
 
-        for channel in channels {
-            let channel: u8 = channel.into();
-            let address = hex::encode(address.to_vec()).to_uppercase();
-            found.push(format!("radio://0/{}/2M/{}", channel, address));
-        }
-
-        // Spawn a blocking function onto the runtime
-        let found = tokio::task::spawn_blocking(|| {
-            for device in DeviceList::new()?.iter() {
-                let device_desc = match device.device_descriptor() {
-                    Ok(d) => d,
-                    Err(_) => continue,
-                };
-
-                if device_desc.vendor_id() == 0x0483 && device_desc.product_id() == 0x5740 {
-                    let timeout = Duration::from_secs(1);
-                    let handle = match device.open() {
-                        Ok(d) => d,
-                        Err(_) => continue,
-                    };
-
-                    let language = match handle.read_languages(timeout).unwrap_or_default().first()
-                    {
-                        Some(l) => *l,
-                        None => continue,
-                    };
-
-                    let serial =
-                        handle.read_serial_number_string(language, &device_desc, timeout)?;
-
-                    found.push(format!("usb://{}", serial));
-                }
-            }
-            Result::<_>::Ok(found)
-        })
-        .await
-        .unwrap()?;
+        found.extend(CrazyradioConnection::scan(self, address).await?);
+        found.extend(CrazyflieUSBConnection::scan().await?);
 
         Ok(found)
     }
@@ -118,21 +69,13 @@ impl LinkContext {
     /// Send a packet to each URI and detect if an acknowledgement is sent back.
     ///
     /// Returns the list of URIs that acknowledged
-    pub async fn scan_selected(&self, _uris: Vec<&str>) -> Result<Vec<String>> {
-        // let mut found = Vec::new();
-        // for uri in uris {
-        //     let (radio_nth, channel, address, _) = self.parse_uri(uri)?;
-        //     let radio = self.get_radio(radio_nth).await?;
-        //     let (ack, _) = radio
-        //         .send_packet_async(channel, address, vec![0xFF, 0xFF, 0xFF])
-        //         .await?;
-        //     if ack.received {
-        //         found.push(format!("{}{}", uri, "?safelink=0&ackfilter=0"));
-        //     }
-        // }
-        // Ok(found)
+    pub async fn scan_selected(&self, uris: Vec<&str>) -> Result<Vec<String>> {
+        let mut found = Vec::new();
 
-        todo!()
+        found.extend(CrazyradioConnection::scan_selected(self, uris.clone()).await?);
+        found.extend(CrazyflieUSBConnection::scan_selected(uris).await?);
+
+        Ok(found)
     }
 
     /// Open a link connection to a given URI

--- a/crazyflie-link/src/crazyflie_usb_connection.rs
+++ b/crazyflie-link/src/crazyflie_usb_connection.rs
@@ -1,16 +1,16 @@
 use crate::connection::ConnectionTrait;
 use crate::error::{Error, Result};
 use crate::{ConnectionStatus, LinkContext, Packet};
+use async_trait::async_trait;
 use futures_channel::oneshot;
 use futures_util::lock::Mutex;
-use log::{debug, info, warn, error};
+use log::{debug, error, info, warn};
+use rusb::{DeviceHandle, DeviceList, GlobalContext};
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::Relaxed;
 use std::sync::Arc;
-use url::Url;
-use async_trait::async_trait;
-use rusb::{DeviceHandle, DeviceList, GlobalContext};
 use std::time::Duration;
+use url::Url;
 
 /// A USB connection to a Crazyflie
 pub struct CrazyflieUSBConnection {
@@ -23,58 +23,58 @@ pub struct CrazyflieUSBConnection {
     /// Channel to signal the waiting callers that the connection has been closed
     disconnect_channel: flume::Receiver<()>,
     /// Flag to signal the user requested disconnection
-    disconnect: Arc<AtomicBool>
+    disconnect: Arc<AtomicBool>,
 }
 
 impl CrazyflieUSBConnection {
-    pub async fn open(_link_context: &LinkContext, uri: &str) -> Result<Option<CrazyflieUSBConnection>> {
+    pub async fn open(
+        _link_context: &LinkContext,
+        uri: &str,
+    ) -> Result<Option<CrazyflieUSBConnection>> {
         let serial = Self::parse_uri(uri)?;
 
-        let (
-            _device_desc,
-            handle,
-            handle_ctrl
-          ) = tokio::task::spawn_blocking(move || {
-          for device in DeviceList::new()?.iter() {
-            let device_desc = match device.device_descriptor() {
-                Ok(d) => d,
-                Err(_) => continue,
-            };
-  
-            if device_desc.vendor_id() == 0x0483 && device_desc.product_id() == 0x5740 {
-                let timeout = Duration::from_secs(1);
-
-                let handle = match device.open() {
-                  Ok(d) => d,
-                  Err(_) => continue,
+        let (_device_desc, handle, handle_ctrl) = tokio::task::spawn_blocking(move || {
+            for device in DeviceList::new()?.iter() {
+                let device_desc = match device.device_descriptor() {
+                    Ok(d) => d,
+                    Err(_) => continue,
                 };
 
-                handle.claim_interface(0)?;
+                if device_desc.vendor_id() == 0x0483 && device_desc.product_id() == 0x5740 {
+                    let timeout = Duration::from_secs(1);
 
-                let handle_ctrl = match device.open() {
-                  Ok(d) => d,
-                  Err(_) => continue,
-                };
-  
-              let language = match handle.read_languages(timeout).unwrap_or_default().first() {
-                Some(l) => *l,
-                None => continue,
-              };
-  
-              let detected_serial = handle.read_serial_number_string(language, &device_desc, timeout)?;
-              
-              if detected_serial == serial {
-                return Ok((device_desc, handle, handle_ctrl));
-              }
+                    let handle = match device.open() {
+                        Ok(d) => d,
+                        Err(_) => continue,
+                    };
+
+                    handle.claim_interface(0)?;
+
+                    let handle_ctrl = match device.open() {
+                        Ok(d) => d,
+                        Err(_) => continue,
+                    };
+
+                    let language = match handle.read_languages(timeout).unwrap_or_default().first()
+                    {
+                        Some(l) => *l,
+                        None => continue,
+                    };
+
+                    let detected_serial =
+                        handle.read_serial_number_string(language, &device_desc, timeout)?;
+
+                    if detected_serial == serial {
+                        return Ok((device_desc, handle, handle_ctrl));
+                    }
+                }
             }
-          }
-          Err(Error::InvalidUri)
-        }).await.unwrap()?;
+            Err(Error::InvalidUri)
+        })
+        .await
+        .unwrap()?;
 
-        let connection = CrazyflieUSBConnection::new(
-          handle,
-          handle_ctrl
-        ).await?;
+        let connection = CrazyflieUSBConnection::new(handle, handle_ctrl).await?;
 
         Ok(Some(connection))
     }
@@ -97,90 +97,89 @@ impl CrazyflieUSBConnection {
         let conn_status = status.clone();
 
         tokio::task::spawn_blocking(move || {
-
-                // Switch the Crazyflie into USB communication mode
-                match usb_handle_ctrl.write_control(64, 0x01,  0x01, 0x01, &[], Duration::from_secs(1)) {
-                  Ok(_) => debug!("Switched to USB communication mode"),
-                  Err(e) => {
+            // Switch the Crazyflie into USB communication mode
+            match usb_handle_ctrl.write_control(64, 0x01, 0x01, 0x01, &[], Duration::from_secs(1)) {
+                Ok(_) => debug!("Switched to USB communication mode"),
+                Err(e) => {
                     error!("Error switching to USB communication mode: {:?}", e);
-                    return
-                  }
+                    return;
                 }
+            }
 
-                let inner_status = conn_status.clone();
-                tokio::runtime::Handle::current().block_on(async move {
-                  let mut status = inner_status.lock().await;
-                  *status = ConnectionStatus::Connected;
-                });
+            let inner_status = conn_status.clone();
+            tokio::runtime::Handle::current().block_on(async move {
+                let mut status = inner_status.lock().await;
+                *status = ConnectionStatus::Connected;
+            });
 
-                connection_initialized_send.send(()).unwrap();
+            connection_initialized_send.send(()).unwrap();
 
-                let thread_handle = std::thread::spawn::<_, Result<_>>(move || {
-                    info!("Communication thread started");
-                    loop {
-                      let mut buf = vec![0; 64];
-                      match usb_handle.read_bulk(0x81, &mut buf, Duration::from_millis(20)) {
+            let thread_handle = std::thread::spawn::<_, Result<_>>(move || {
+                info!("Communication thread started");
+                loop {
+                    let mut buf = vec![0; 64];
+                    match usb_handle.read_bulk(0x81, &mut buf, Duration::from_millis(20)) {
                         Ok(n) => {
-                          if n > 0 {
-                            let packet = buf[0..n].to_vec();
-                            downlink_send.send(packet)?;
-                          }
-                        },
-                        Err(rusb::Error::Timeout) => {},
-                        Err(e) => {
-                          warn!("Downlink thread error: {:?}", e);
-                          return Err(e.into());
+                            if n > 0 {
+                                let packet = buf[0..n].to_vec();
+                                downlink_send.send(packet)?;
+                            }
                         }
-                      }
+                        Err(rusb::Error::Timeout) => {}
+                        Err(e) => {
+                            warn!("Downlink thread error: {:?}", e);
+                            return Err(e.into());
+                        }
+                    }
 
-                      while !uplink_recv.is_empty() {
+                    while !uplink_recv.is_empty() {
                         let packet = uplink_recv.recv()?;
                         match usb_handle.write_bulk(0x01, &packet, Duration::from_millis(100)) {
-                          Ok(_) => {},
-                          Err(e) => {
-                            warn!("Uplink thread error: {:?}", e);
-                            return Err(e.into());
-                          }
-                      }
+                            Ok(_) => {}
+                            Err(e) => {
+                                warn!("Uplink thread error: {:?}", e);
+                                return Err(e.into());
+                            }
+                        }
                     }
 
                     // If the connection object has been dropped, leave the thread
                     if conn_disconnect.load(Relaxed) {
-                      debug!("Disconnect requested, leaving connection loop.");
-                      return Ok(());
+                        debug!("Disconnect requested, leaving connection loop.");
+                        return Ok(());
                     }
-                  }
-                });
-
-                let disconnect_message = match thread_handle.join() {
-                  Ok(Ok(())) => format!("Connection closed"),
-                  Ok(Err(e)) => {
-                    error!("Connection thread error: {:?}", e);
-                    format!("USB error: {:?}", e)
-                  },
-                  Err(e) => {
-                    error!("Connection thread panicked: {:?}", e);
-                    format!("Connection thread panicked: {:?}", e)
-                  }
-                };
-
-                let inner_status = conn_status.clone();
-                tokio::runtime::Handle::current().block_on(async move {
-                  let mut status = inner_status.lock().await;
-                  *status = ConnectionStatus::Disconnected(disconnect_message)
-                });
-                
-                // Best effort, do not care if the other side is dropped
-                let _ =  disconnect_channel_tx.send(());
-
-                // Switch the Crazyflie back into Crazyradio mode
-                match usb_handle_ctrl.write_control(64, 0x01,  0x01, 0x00, &[], Duration::from_secs(1)) {
-                  Ok(_) => debug!("Switched back to CR mode in CF"),
-                  Err(e) => {
-                    error!("Error switching back to CR mode in CF: {:?}", e);
-                  }
                 }
             });
+
+            let disconnect_message = match thread_handle.join() {
+                Ok(Ok(())) => format!("Connection closed"),
+                Ok(Err(e)) => {
+                    error!("Connection thread error: {:?}", e);
+                    format!("USB error: {:?}", e)
+                }
+                Err(e) => {
+                    error!("Connection thread panicked: {:?}", e);
+                    format!("Connection thread panicked: {:?}", e)
+                }
+            };
+
+            let inner_status = conn_status.clone();
+            tokio::runtime::Handle::current().block_on(async move {
+                let mut status = inner_status.lock().await;
+                *status = ConnectionStatus::Disconnected(disconnect_message)
+            });
+
+            // Best effort, do not care if the other side is dropped
+            let _ = disconnect_channel_tx.send(());
+
+            // Switch the Crazyflie back into Crazyradio mode
+            match usb_handle_ctrl.write_control(64, 0x01, 0x01, 0x00, &[], Duration::from_secs(1)) {
+                Ok(_) => debug!("Switched back to CR mode in CF"),
+                Err(e) => {
+                    error!("Error switching back to CR mode in CF: {:?}", e);
+                }
+            }
+        });
 
         // Wait for, either, the connection being established or failed initialization
         connection_initialized.await.unwrap();
@@ -190,29 +189,29 @@ impl CrazyflieUSBConnection {
             disconnect_channel: disconnect_channel_rx,
             uplink: uplink_send,
             downlink: downlink_recv,
-            disconnect
+            disconnect,
         })
     }
 
     fn parse_uri(uri: &str) -> Result<String> {
-      let uri = Url::parse(uri)?;
+        let uri = Url::parse(uri)?;
 
-      if uri.scheme() != "usb" {
-          return Err(Error::InvalidUriScheme);
-      }
+        if uri.scheme() != "usb" {
+            return Err(Error::InvalidUriScheme);
+        }
 
-      let serial = uri.domain().ok_or(Error::InvalidUri)?;
+        let serial = uri.domain().ok_or(Error::InvalidUri)?;
 
-      if uri.path_segments().is_some() {
-        return Err(Error::InvalidUri);
-      }
+        if uri.path_segments().is_some() {
+            return Err(Error::InvalidUri);
+        }
 
-      Ok(serial.to_owned())
-  }
-  }
+        Ok(serial.to_owned())
+    }
+}
 
-  #[async_trait]
-  impl ConnectionTrait for CrazyflieUSBConnection {
+#[async_trait]
+impl ConnectionTrait for CrazyflieUSBConnection {
     /// Wait for the connection to be closed. Returns the message stored in the
     /// disconnected connection status that indicate the reason for the disconnection
     async fn wait_close(&self) -> String {

--- a/crazyflie-link/src/crazyflie_usb_connection.rs
+++ b/crazyflie-link/src/crazyflie_usb_connection.rs
@@ -1,0 +1,250 @@
+use crate::connection::ConnectionTrait;
+use crate::error::{Error, Result};
+use crate::{ConnectionStatus, LinkContext, Packet};
+use futures_channel::oneshot;
+use futures_util::lock::Mutex;
+use log::{debug, info, warn};
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::Arc;
+use url::Url;
+use async_trait::async_trait;
+use rusb::{DeviceHandle, DeviceList, GlobalContext};
+use std::time::Duration;
+
+/// Link connection
+pub struct CrazyflieUSBConnection {
+    status: Arc<Mutex<ConnectionStatus>>,
+    uplink: flume::Sender<Vec<u8>>,
+    downlink: flume::Receiver<Vec<u8>>,
+    disconnect_channel: flume::Receiver<()>,
+    disconnect: Arc<AtomicBool>
+}
+
+impl CrazyflieUSBConnection {
+    pub async fn open(_link_context: &LinkContext, uri: &str) -> Result<Option<CrazyflieUSBConnection>> {
+        let serial = Self::parse_uri(uri)?;
+
+        let (_device_desc, handle) = tokio::task::spawn_blocking(move || {
+          for device in DeviceList::new()?.iter() {
+            let device_desc = match device.device_descriptor() {
+                Ok(d) => d,
+                Err(_) => continue,
+            };
+  
+            if device_desc.vendor_id() == 0x0483 && device_desc.product_id() == 0x5740 {
+                let timeout = Duration::from_secs(1);
+                let handle = match device.open() {
+                  Ok(d) => d,
+                  Err(_) => continue,
+                };
+  
+              let language = match handle.read_languages(timeout).unwrap_or_default().first() {
+                Some(l) => *l,
+                None => continue,
+              };
+  
+              let detected_serial = handle.read_serial_number_string(language, &device_desc, timeout)?;
+              
+              if detected_serial == serial {
+                return Ok((device_desc, handle));
+              }
+            }
+          }
+          Err(Error::InvalidUri)
+        }).await.unwrap()?;
+
+        let connection = CrazyflieUSBConnection::new(handle).await?;
+
+        Ok(Some(connection))
+    }
+
+    async fn new(
+        usb_handle: DeviceHandle<GlobalContext>
+    ) -> Result<CrazyflieUSBConnection> {
+        let status = Arc::new(Mutex::new(ConnectionStatus::Connecting));
+
+        let (disconnect_channel_tx, disconnect_channel_rx) = flume::bounded(0);
+        let disconnect = Arc::new(AtomicBool::new(false));
+
+        let (uplink_send, uplink_recv) = flume::bounded(1000);
+        let (downlink_send, downlink_recv) = flume::bounded(1000);
+
+        let (connection_initialized_send, connection_initialized) = oneshot::channel();
+
+        let mut thread = ConnectionThread {
+            usb_handle,
+            status: status.clone(),
+            disconnect_channel: disconnect_channel_tx,
+            uplink: uplink_recv,
+            downlink: downlink_send,
+            disconnect: disconnect.clone(),
+        };
+        tokio::spawn(async move {
+                if let Err(e) = thread.run(connection_initialized_send).await {
+                    thread
+                        .update_status(ConnectionStatus::Disconnected(format!(
+                            "Connection error: {}",
+                            e
+                        )))
+                        .await;
+                }
+                drop(thread.disconnect_channel);
+            });
+
+        // Wait for, either, the connection being established or failed initialization
+        connection_initialized.await.unwrap();
+
+        Ok(CrazyflieUSBConnection {
+            status,
+            disconnect_channel: disconnect_channel_rx,
+            uplink: uplink_send,
+            downlink: downlink_recv,
+            disconnect
+        })
+    }
+
+    fn parse_uri(uri: &str) -> Result<String> {
+      let uri = Url::parse(uri)?;
+
+      if uri.scheme() != "usb" {
+          return Err(Error::InvalidUriScheme);
+      }
+
+      let serial = uri.domain().ok_or(Error::InvalidUri)?;
+
+      if uri.path_segments().is_some() {
+        return Err(Error::InvalidUri);
+      }
+
+      Ok(serial.to_owned())
+  }
+  }
+
+  #[async_trait]
+  impl ConnectionTrait for CrazyflieUSBConnection {
+    /// Wait for the connection to be closed. Returns the message stored in the
+    /// disconnected connection status that indicate the reason for the disconnection
+    async fn wait_close(&self) -> String {
+        // Wait for the connection thread to drop the disconnect channel
+        let _ = self.disconnect_channel.recv_async().await;
+        if let ConnectionStatus::Disconnected(reason) = self.status().await {
+            reason
+        } else {
+            "Still connected!".to_owned()
+        }
+    }
+
+    /// Close the connection and wait for the connection task to stop.
+    ///
+    /// The connection can also be closed by simply dropping the connection object.
+    /// Though, if the connection task is currently processing a packet, it will continue running
+    /// until the current packet has been processed. This function will wait for any ongoing packet
+    /// to be processed and for the communication task to stop.
+    async fn close(&self) {
+        self.disconnect.store(true, Relaxed);
+        let _ = self.disconnect_channel.recv_async().await;
+    }
+
+    /// Return the connection status
+    async fn status(&self) -> ConnectionStatus {
+        self.status.lock().await.clone()
+    }
+
+    /// Block until the connection is dropped. The `status()` function can be used to get the reason
+    /// for the disconnection.
+    async fn wait_disconnect(&self) {
+        // The channel will return an error when the other side, in the connection thread, is dropped
+        let _ = self.disconnect_channel.recv_async().await;
+    }
+
+    /// Send a packet to the connected Crazyflie
+    ///
+    /// This fundtion can return an error if the connection task is not active anymore.
+    /// This can happen if the Crazyflie is disconnected due to a timeout
+    async fn send_packet(&self, packet: Packet) -> Result<()> {
+        self.uplink.send_async(packet.into()).await?;
+        Ok(())
+    }
+
+    /// Receive a packet from the connected Crazyflie
+    ///
+    /// This fundtion can return an error if the connection task is not active anymore.
+    /// This can happen if the Crazyflie is disconnected due to a timeout
+    async fn recv_packet(&self) -> Result<Packet> {
+        let packet = self.downlink.recv_async().await?;
+        Ok(packet.into())
+    }
+}
+
+impl Drop for CrazyflieUSBConnection {
+    fn drop(&mut self) {
+        self.disconnect.store(true, Relaxed);
+    }
+}
+
+struct ConnectionThread {
+    usb_handle: DeviceHandle<GlobalContext>,
+    status: Arc<Mutex<ConnectionStatus>>,
+    disconnect_channel: flume::Sender<()>,
+    uplink: flume::Receiver<Vec<u8>>,
+    downlink: flume::Sender<Vec<u8>>,
+    disconnect: Arc<AtomicBool>,
+}
+
+impl ConnectionThread {
+    async fn update_status(&self, new_status: ConnectionStatus) {
+        debug!("New status: {:?}", &new_status);
+        let mut status = self.status.lock().await;
+        *status = new_status;
+    }
+
+    async fn run(&mut self, connection_initialized: oneshot::Sender<()>) -> Result<()> {
+        info!("Connecting to USB device");
+
+        self.usb_handle.write_control(64, 0x01,  0x01, 0x01, &[], Duration::from_secs(1))?;
+
+        self.update_status(ConnectionStatus::Connected).await;
+        connection_initialized.send(()).unwrap();
+
+        let mut buf = [0u8; 64];
+
+        loop {
+          match self.usb_handle.read_bulk(0x81, &mut buf, Duration::from_millis(20)) {
+            Ok(n) => {
+              if n > 0 {
+                let packet = buf[0..n].to_vec();
+                self.downlink.send_async(packet).await?;
+              }
+            },
+            Err(rusb::Error::Timeout) => {
+              continue;
+            },
+            Err(e) => {
+              warn!("Error: {:?}", e);
+              self.update_status(ConnectionStatus::Disconnected(
+                format!("Connection error: {:?}", e).to_string(),
+              ))
+              .await;
+              return Ok(());          
+            }
+          }
+ 
+          if self.uplink.len() > 0 {
+            let packet = self.uplink.recv_async().await?;
+            self.usb_handle.write_bulk(0x01, &packet, Duration::from_millis(20))?;
+          }
+
+          // If the connection object has been dropped, leave the thread
+          if self.disconnect.load(Relaxed) {
+            debug!("Disconnect requested, leaving connection loop.");
+            self.usb_handle.write_control(64, 0x01,  0x01, 0x00, &[], Duration::from_secs(1))?;
+            self.update_status(ConnectionStatus::Disconnected(
+                "Connection closed".to_owned(),
+            ))
+            .await;
+            return Ok(());
+          }
+        }
+    }
+}

--- a/crazyflie-link/src/crazyradio_connection.rs
+++ b/crazyflie-link/src/crazyradio_connection.rs
@@ -1,0 +1,404 @@
+use crate::connection::ConnectionTrait;
+// Connection handling code
+use crate::crazyradio::{Channel, SharedCrazyradio};
+use crate::error::{Error, Result};
+use crate::{ConnectionStatus, LinkContext, Packet};
+use futures_channel::oneshot;
+use futures_util::lock::Mutex;
+use log::{debug, info, warn};
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::Arc;
+use url::Url;
+use hex::FromHex;
+use async_trait::async_trait;
+
+use std::time;
+
+use std::time::Instant;
+
+const EMPTY_PACKET_BEFORE_RELAX: u32 = 10;
+
+bitflags! {
+    pub struct ConnectionFlags: u32 {
+        const SAFELINK = 0b00000001;
+        const ACKFILTER = 0b00000010;
+    }
+}
+
+/// Link connection
+pub struct CrazyradioConnection {
+    status: Arc<Mutex<ConnectionStatus>>,
+    uplink: flume::Sender<Vec<u8>>,
+    downlink: flume::Receiver<Vec<u8>>,
+    disconnect_channel: flume::Receiver<()>,
+    disconnect: Arc<AtomicBool>
+}
+
+impl CrazyradioConnection {
+    pub async fn open(link_context: &LinkContext, uri: &str) -> Result<Option<impl ConnectionTrait>> {
+        let (radio, channel, address, flags) = Self::parse_uri(uri)?;
+
+        let radio = link_context.get_radio(radio).await?;
+        let connection = CrazyradioConnection::new(radio, channel, address, flags).await?;
+
+        Ok(Some(connection))
+    }
+
+    async fn new(
+        radio: Arc<SharedCrazyradio>,
+        channel: Channel,
+        address: [u8; 5],
+        flags: ConnectionFlags,
+    ) -> Result<CrazyradioConnection> {
+        let status = Arc::new(Mutex::new(ConnectionStatus::Connecting));
+
+        let (disconnect_channel_tx, disconnect_channel_rx) = flume::bounded(0);
+        let disconnect = Arc::new(AtomicBool::new(false));
+
+        let (uplink_send, uplink_recv) = flume::bounded(1000);
+        let (downlink_send, downlink_recv) = flume::bounded(1000);
+
+        let (connection_initialized_send, connection_initialized) = oneshot::channel();
+
+        let mut thread = ConnectionThread {
+            radio,
+            status: status.clone(),
+            disconnect_channel: disconnect_channel_tx,
+            safelink_down_ctr: 0,
+            safelink_up_ctr: 0,
+            uplink: uplink_recv,
+            downlink: downlink_send,
+            channel,
+            address,
+            flags,
+            disconnect: disconnect.clone(),
+        };
+        tokio::spawn(async move {
+                if let Err(e) = thread.run(connection_initialized_send).await {
+                    thread
+                        .update_status(ConnectionStatus::Disconnected(format!(
+                            "Connection error: {}",
+                            e
+                        )))
+                        .await;
+                }
+                drop(thread.disconnect_channel);
+            });
+
+        // Wait for, either, the connection being established or failed initialization
+        connection_initialized.await.unwrap();
+
+        Ok(CrazyradioConnection {
+            status,
+            disconnect_channel: disconnect_channel_rx,
+            uplink: uplink_send,
+            downlink: downlink_recv,
+            disconnect
+        })
+    }
+
+    fn parse_uri(uri: &str) -> Result<(usize, Channel, [u8; 5], ConnectionFlags)> {
+      let uri = Url::parse(uri)?;
+
+      if uri.scheme() != "radio" {
+          return Err(Error::InvalidUri);
+      }
+
+      let radio: usize = uri.domain().ok_or(Error::InvalidUri)?.parse()?;
+
+      let path: Vec<&str> = uri.path_segments().ok_or(Error::InvalidUri)?.collect();
+      if path.len() != 3 {
+          return Err(Error::InvalidUri);
+      }
+      let channel = Channel::from_number(path[0].parse()?)?;
+      let _rate = path[1];
+      let addr_str = path[2];
+
+      if addr_str.len() > 10 {
+          return Err(Error::InvalidUri);
+      }
+
+      let address = match <[u8; 5]>::from_hex(format!("{:0>10}", addr_str)) {
+          Ok(address) => address,
+          Err(_) => return Err(Error::InvalidUri),
+      };
+
+      let mut flags = ConnectionFlags::SAFELINK | ConnectionFlags::ACKFILTER;
+      for (key, value) in uri.query_pairs() {
+          match key.as_ref() {
+              "safelink" => {
+                  if value == "0" {
+                      flags.remove(ConnectionFlags::SAFELINK);
+                  }
+              }
+              "ackfilter" => {
+                  if value == "0" {
+                      flags.remove(ConnectionFlags::ACKFILTER);
+                  }
+              }
+              _ => continue,
+          };
+      }
+
+      Ok((radio, channel, address, flags))
+  }
+  }
+
+  #[async_trait]
+  impl ConnectionTrait for CrazyradioConnection {
+    /// Wait for the connection to be closed. Returns the message stored in the
+    /// disconnected connection status that indicate the reason for the disconnection
+    async fn wait_close(&self) -> String {
+        // Wait for the connection thread to drop the disconnect channel
+        let _ = self.disconnect_channel.recv_async().await;
+        if let ConnectionStatus::Disconnected(reason) = self.status().await {
+            reason
+        } else {
+            "Still connected!".to_owned()
+        }
+    }
+
+    /// Close the connection and wait for the connection task to stop.
+    ///
+    /// The connection can also be closed by simply dropping the connection object.
+    /// Though, if the connection task is currently processing a packet, it will continue running
+    /// until the current packet has been processed. This function will wait for any ongoing packet
+    /// to be processed and for the communication task to stop.
+    async fn close(&self) {
+        self.disconnect.store(true, Relaxed);
+        let _ = self.disconnect_channel.recv_async().await;
+    }
+
+    /// Return the connection status
+    async fn status(&self) -> ConnectionStatus {
+        self.status.lock().await.clone()
+    }
+
+    /// Block until the connection is dropped. The `status()` function can be used to get the reason
+    /// for the disconnection.
+    async fn wait_disconnect(&self) {
+        // The channel will return an error when the other side, in the connection thread, is dropped
+        let _ = self.disconnect_channel.recv_async().await;
+    }
+
+    /// Send a packet to the connected Crazyflie
+    ///
+    /// This fundtion can return an error if the connection task is not active anymore.
+    /// This can happen if the Crazyflie is disconnected due to a timeout
+    async fn send_packet(&self, packet: Packet) -> Result<()> {
+        self.uplink.send_async(packet.into()).await?;
+        Ok(())
+    }
+
+    /// Receive a packet from the connected Crazyflie
+    ///
+    /// This fundtion can return an error if the connection task is not active anymore.
+    /// This can happen if the Crazyflie is disconnected due to a timeout
+    async fn recv_packet(&self) -> Result<Packet> {
+        let packet = self.downlink.recv_async().await?;
+        Ok(packet.into())
+    }
+}
+
+impl Drop for CrazyradioConnection {
+    fn drop(&mut self) {
+        self.disconnect.store(true, Relaxed);
+    }
+}
+
+struct ConnectionThread {
+    radio: Arc<SharedCrazyradio>,
+    status: Arc<Mutex<ConnectionStatus>>,
+    disconnect_channel: flume::Sender<()>,
+    safelink_up_ctr: u8,
+    safelink_down_ctr: u8,
+    uplink: flume::Receiver<Vec<u8>>,
+    downlink: flume::Sender<Vec<u8>>,
+    channel: Channel,
+    address: [u8; 5],
+    flags: ConnectionFlags,
+    disconnect: Arc<AtomicBool>,
+}
+
+impl ConnectionThread {
+    async fn update_status(&self, new_status: ConnectionStatus) {
+        debug!("New status: {:?}", &new_status);
+        let mut status = self.status.lock().await;
+        *status = new_status;
+    }
+
+    async fn enable_safelink(&mut self) -> Result<bool> {
+        // Tying 10 times to reset safelink
+        for _ in 0..10 {
+            let (ack, payload) = self
+                .radio
+                .send_packet_async(self.channel, self.address, vec![0xff, 0x05, 0x01])
+                .await?;
+
+            if ack.received && payload == [0xff, 0x05, 0x01] {
+                self.safelink_down_ctr = 0;
+                self.safelink_up_ctr = 0;
+
+                // Safelink enabled!
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    async fn send_packet_safe(
+        &mut self,
+        packet: Vec<u8>,
+    ) -> Result<(crate::crazyradio::Ack, Vec<u8>)> {
+        let mut packet = packet;
+        packet[0] &= 0xF3;
+        packet[0] |= (self.safelink_up_ctr << 3) | (self.safelink_down_ctr << 2);
+
+        let (ack, mut ack_payload) = self
+            .radio
+            .send_packet_async(self.channel, self.address, packet)
+            .await?;
+
+        if ack.received {
+            self.safelink_up_ctr = 1 - self.safelink_up_ctr;
+        }
+
+        if ack.received
+            && !ack_payload.is_empty()
+            && (ack_payload[0] & 0x04) >> 2 == self.safelink_down_ctr
+        {
+            self.safelink_down_ctr = 1 - self.safelink_down_ctr;
+        } else {
+            // If the down counter does not match, this is a reapeted ack and the payload needs to be dropped
+            ack_payload.clear();
+        }
+
+        Ok((ack, ack_payload))
+    }
+
+    async fn send_packet(
+        &mut self,
+        packet: Vec<u8>,
+        safe: bool,
+    ) -> Result<(crate::crazyradio::Ack, Vec<u8>)> {
+        let result = if safe {
+            self.send_packet_safe(packet).await?
+        } else {
+            self.radio
+                .send_packet_async(self.channel, self.address, packet)
+                .await?
+        };
+
+        Ok(result)
+    }
+
+    fn use_safelink(&self) -> bool {
+        self.flags.contains(ConnectionFlags::SAFELINK)
+    }
+
+    //
+    // In order to know whether or not to handle and send this ack back to
+    // the receiver we need to check some stuff.
+    //
+    // In safelink we deem a payload empty if it only containx 0xF3, and we do
+    // not handle it.
+    //
+    // When not using safelink (perhaps communicating with bootloader) we check
+    // if the ackfilter flag is not set. If we have no ack filter then we
+    // handle payload-less acks as well.
+    //
+    fn preprocess_ack(&self, payload: &mut Vec<u8>, safelink: bool) -> bool {
+        if safelink {
+            if !payload.is_empty() && payload[0] & 0xF3 != 0xF3 {
+                payload[0] &= 0xF3;
+                return true;
+            }
+            return false;
+        }
+
+        // not safelink
+
+        if !payload.is_empty() {
+            return true;
+        }
+
+        if !self.flags.contains(ConnectionFlags::ACKFILTER) {
+            *payload = vec![0xFF];
+            return true;
+        }
+
+        false
+    }
+
+    async fn run(&mut self, connection_initialized: oneshot::Sender<()>) -> Result<()> {
+        info!("Connecting to {:?}/{:X?} ...", self.channel, self.address);
+
+        // Try to initialize safelink if in use
+        let safelink = self.use_safelink() && self.enable_safelink().await?;
+
+        self.update_status(ConnectionStatus::Connected).await;
+        connection_initialized.send(()).unwrap();
+
+        // Communication loop ...
+        let mut last_pk_time = Instant::now();
+        let mut n_empty_packets = 0;
+        let mut packet = vec![0xff];
+        let mut needs_resend = false;
+        while last_pk_time.elapsed() < time::Duration::from_millis(1000) {
+            if !needs_resend {
+                packet = if self.uplink.is_empty() {
+                    vec![0xff]
+                } else {
+                    self.uplink.recv_async().await?
+                }
+            }
+
+            let (ack, mut ack_payload) = self.send_packet(packet.clone(), safelink).await?;
+
+            debug!("Packet sent!");
+
+            if ack.received {
+                last_pk_time = Instant::now();
+                needs_resend = false;
+
+                // Add some relaxation time if the Crazyflie has nothing to send back
+                // for a while
+
+                let should_handle = self.preprocess_ack(&mut ack_payload, safelink);
+                if should_handle {
+                    self.downlink.send(ack_payload)?;
+                } else if n_empty_packets > EMPTY_PACKET_BEFORE_RELAX {
+                    // If no packet received for a while, relax packet pulling
+                } else {
+                    n_empty_packets += 1;
+                }
+            } else {
+                debug!("Lost packet!");
+                needs_resend = true;
+            }
+
+            // If the connection object has been dropped, leave the thread
+            if self.disconnect.load(Relaxed) {
+                debug!("Disconnect requested, leaving connection loop.");
+                self.update_status(ConnectionStatus::Disconnected(
+                    "Connection closed".to_owned(),
+                ))
+                .await;
+                return Ok(());
+            }
+        }
+
+        self.update_status(ConnectionStatus::Disconnected(
+            "Connection timeout".to_string(),
+        ))
+        .await;
+
+        warn!(
+            "Connection to {:?}/{:X?} lost (timeout)",
+            self.channel, self.address
+        );
+
+        Ok(())
+    }
+}

--- a/crazyflie-link/src/error.rs
+++ b/crazyflie-link/src/error.rs
@@ -15,6 +15,8 @@ pub enum Error {
     ChannelRecvError(flume::RecvError),
     #[error("Threading error: {0:?}")]
     ChannelSendError(flume::SendError<Vec<u8>>),
+    #[error("USB error: {0:?}")]
+    USBSubsystemError(rusb::Error),
 }
 
 impl From<crate::crazyradio::Error> for Error {
@@ -51,4 +53,10 @@ impl From<RecvTimeoutError> for Error {
     fn from(_error: RecvTimeoutError) -> Self {
         Error::Timeout
     }
+}
+
+impl From<rusb::Error> for Error {
+  fn from(error: rusb::Error) -> Self {
+      Error::USBSubsystemError(error)
+  }
 }

--- a/crazyflie-link/src/error.rs
+++ b/crazyflie-link/src/error.rs
@@ -5,6 +5,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error("Invalid URI scheme")]
+    InvalidUriScheme,
     #[error("Invalid URI")]
     InvalidUri,
     #[error("Timeout")]

--- a/crazyflie-link/src/error.rs
+++ b/crazyflie-link/src/error.rs
@@ -58,7 +58,7 @@ impl From<RecvTimeoutError> for Error {
 }
 
 impl From<rusb::Error> for Error {
-  fn from(error: rusb::Error) -> Self {
-      Error::USBSubsystemError(error)
-  }
+    fn from(error: rusb::Error) -> Self {
+        Error::USBSubsystemError(error)
+    }
 }

--- a/crazyflie-link/src/lib.rs
+++ b/crazyflie-link/src/lib.rs
@@ -35,6 +35,7 @@
 extern crate bitflags;
 
 mod connection;
+mod crazyradio_connection;
 mod context;
 mod error;
 mod packet;

--- a/crazyflie-link/src/lib.rs
+++ b/crazyflie-link/src/lib.rs
@@ -35,9 +35,9 @@
 extern crate bitflags;
 
 mod connection;
-mod crazyradio_connection;
-mod crazyflie_usb_connection;
 mod context;
+mod crazyflie_usb_connection;
+mod crazyradio_connection;
 mod error;
 mod packet;
 

--- a/crazyflie-link/src/lib.rs
+++ b/crazyflie-link/src/lib.rs
@@ -36,6 +36,7 @@ extern crate bitflags;
 
 mod connection;
 mod crazyradio_connection;
+mod crazyflie_usb_connection;
 mod context;
 mod error;
 mod packet;


### PR DESCRIPTION
Added support for connecting a Crazyflie via USB. For this to be implemented the connection logic was refactored to support different links, not only Crazyradio.

Note that in order for the Crazyflie to be able to reconnect using the Crazyradio (without resetting) the connection object needs to be dropped properly so that the USB CTRL commands to switch the Crazyflie back from USB to Crazyradio connection can be sent, otherwise the Crazyflie firmware will be locked in USB communication until reset.